### PR TITLE
Setup.py long_description for twine upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import os
 import setuptools
 
+with open("README.md") as f:
+    readme = f.read()
+
 setuptools.setup(
     name="waving_hands",
     version="0.1.0",
@@ -9,6 +12,8 @@ setuptools.setup(
     description=(
         "P2P Multiplayer Python implementation of Richard Bartle's Waving Hands"
     ),
+    long_description=readme,
+    long_descritpion_content_type="text/plain",
     license="GNUv3",
     keywords="waving hands turnbased",
     url="https://github.com/alanb33/WavingHands",


### PR DESCRIPTION
Adds long_description and long_description_content_type fields; these are temporary until RST is implemented, required for PyPI upload.