### PR TITLE
fix: Missing data files from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
     keywords="waving hands turnbased",
     url="https://github.com/alanb33/WavingHands",
     packages=setuptools.find_packages(),
+    include_package_data=True,
     entry_points={
         "console_scripts": ["waving-hands = waving_hands.waving_hands:main",],
     },


### PR DESCRIPTION
Fix via: https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data

Adding this line includes data files for both source and binary builds