### PR TITLE
chore: Add automated tests via github actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,32 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with ruff
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          # ruff --format=github --select=E9,F63,F7,F82 --target-version=py311 .
+          # default set of ruff rules with GitHub Annotations
+          # ruff --format=github --target-version=py311 .
+      - name: Test with pytest
+        run: |
+          pytest


### PR DESCRIPTION
Tests will run on any push event. Note that the `ruff` code format checking is turned off for tests -- that will cause a whole bunch of errors until we decide on a formatting style. Black is a common one here: https://pypi.org/project/black/

Another really nice thing to do on top of this is add a tests badge to the README, like this: ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/Nickolausds/WavingHands/python-package.yml). 
The status badge for this repo can be found here:  https://shields.io/badges/git-hub-workflow-status-with-event with settings: 
* User - alanb33
* Repo - WavingHands
* Workflow - python-package.yml

Some other nice badges to add too: 
* https://shields.io/badges/py-pi-license
* https://shields.io/badges/py-pi-version
* https://shields.io/badges/py-pi-python-version
